### PR TITLE
Changes in PartnerIdentity

### DIFF
--- a/events/model_batch.go
+++ b/events/model_batch.go
@@ -16,7 +16,7 @@ type Batch struct {
 	APIKeys               []string                     `json:"api_keys,omitempty"`
 	IP                    string                       `json:"ip,omitempty"`
 	IntegrationAttributes map[string]map[string]string `json:"integration_attributes,omitempty"`
-	PartnerIdentity       string                       `json:"partner_identity,omitempty"`
+	PartnerIdentity       map[string]string            `json:"partner_identity,omitempty"`
 	SourceInfo            *SourceInformation           `json:"source_info,omitempty"`
 	MpDeviceid            string                       `json:"mp_deviceid,omitempty"`
 	AttributionInfo       *AttributionInfo             `json:"attribution_info,omitempty"`


### PR DESCRIPTION
# Summary

As per the updated document `model_batch.go` has `PartnerIdentity` as `map[string]string` instead of `string`
