### PR TITLE
Update model_custom_event_data.go

### DIFF
--- a/events/model_custom_event_data.go
+++ b/events/model_custom_event_data.go
@@ -9,7 +9,7 @@ type CustomEventData struct {
 	SessionUUID                 string                       `json:"session_uuid,omitempty"`
 	SessionStartUnixtimeMS      int64                        `json:"session_start_unixtime_ms,omitempty"`
 	EventStartUnixtimeMS        int64                        `json:"event_start_unixtime_ms,omitempty"`
-	CustomAttributes            map[string]string            `json:"custom_attributes,omitempty"`
+	CustomAttributes            map[string]interface{}       `json:"custom_attributes,omitempty"`
 	Location                    *GeoLocation                 `json:"location,omitempty"`
 	DeviceCurrentState          *DeviceCurrentState          `json:"device_current_state,omitempty"`
 	IsGoalDefined               bool                         `json:"is_goal_defined,omitempty"`


### PR DESCRIPTION
Custom Event's Custom Attributes Type Change

# Summary

Custom Attributes for Custom Events should allow numbers and not force the end-user to convert all their objects to string.
