### PR TITLE
Allow false to be submitted as a value for GDPR consent

### DIFF
--- a/events/model_gdpr_consent_state.go
+++ b/events/model_gdpr_consent_state.go
@@ -4,7 +4,7 @@ package events
 type GdprConsentState struct {
 	Regulation          string `json:"regulation,omitempty,omitempty"`
 	Document            string `json:"document,omitempty,omitempty"`
-	Consented           bool   `json:"consented,omitempty,omitempty"`
+	Consented           bool   `json:"consented"`
 	TimestampUnixtimeMS int64  `json:"timestamp_unixtime_ms,omitempty"`
 	Location            string `json:"location,omitempty"`
 	HardwareID          string `json:"hardware_id,omitempty"`


### PR DESCRIPTION
# Summary

Uploading a batch event with the following consent state:

```
ConsentState: &events.ConsentState{
    GDPR: map[string]events.GdprConsentState{
        "my-purpose": {
            Consented:           false,
            TimestampUnixtimeMS: time.Now().UnixMilli(),
        },
    },
}
```

results in the following API error:

```
{
  "errors": [
    {
      "code": "BAD_REQUEST",
      "message": "Required property 'consented' not found in JSON. Path 'consent_state.gdpr.my-purpose', line 1, position 175."
    }
  ]
}
```

This is because `omitempty` removes the field when marshalling the request, due to `false` being treated as an empty value.

To preserve the behaviour of removing the field when not set, its type could instead be changed `*bool` as the empty value would then become `nil`. Please let me know if you'd prefer this approach.
