### PR TITLE
Replace explicit http.Client usage with specific interface

### DIFF
--- a/events/api_events_test.go
+++ b/events/api_events_test.go
@@ -62,7 +62,7 @@ func TestFullBatch(t *testing.T) {
 	customEvent := NewCustomEvent()
 	customEvent.Data.EventName = "My Custom Event Name"
 	customEvent.Data.CustomEventType = OtherCustomEventType
-	customEvent.Data.CustomAttributes = make(map[string]string)
+	customEvent.Data.CustomAttributes = make(map[string]interface{})
 	customEvent.Data.CustomAttributes["foo"] = "bar"
 
 	screenEvent := NewScreenViewEvent()

--- a/events/configuration.go
+++ b/events/configuration.go
@@ -30,6 +30,10 @@ type BasicAuth struct {
 	APISecret string `json:"apiSecret,omitempty"`
 }
 
+type RequestDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Configuration stores the configuration of the API client
 type Configuration struct {
 	BasePath      string            `json:"basePath,omitempty"`
@@ -37,7 +41,7 @@ type Configuration struct {
 	Scheme        string            `json:"scheme,omitempty"`
 	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
 	UserAgent     string            `json:"userAgent,omitempty"`
-	HTTPClient    *http.Client
+	HTTPClient    RequestDoer
 }
 
 // NewConfiguration returns a new Configuration object


### PR DESCRIPTION
## Summary
This PR replaces explicit http.Client usage with narrow and specific interface.

We need to have ability to intercept outgoing http requests to perform verbose logging.
To achieve that we wrap http.Client with our implementation which passes requests through and logs them.

Also fixes typo in unit tests.

## Testing Plan
You should be able to replace Configuration.HTTPClient with your own implmentation of RequestDoer interface.

## Master Issue
Closes https://github.com/mParticle/mparticle-go-sdk/issues/17