### PR TITLE
feat: add 429 support

### DIFF
--- a/events/api_events_test.go
+++ b/events/api_events_test.go
@@ -62,7 +62,7 @@ func TestFullBatch(t *testing.T) {
 	customEvent := NewCustomEvent()
 	customEvent.Data.EventName = "My Custom Event Name"
 	customEvent.Data.CustomEventType = OtherCustomEventType
-	customEvent.Data.CustomAttributes = make(map[string]string)
+	customEvent.Data.CustomAttributes = make(map[string]interface{})
 	customEvent.Data.CustomAttributes["foo"] = "bar"
 
 	screenEvent := NewScreenViewEvent()


### PR DESCRIPTION
## Summary
Confirm that we’re returning all headers we receive along with the status code in the response. These include the Retry-After header and potentially other mParticle headers.

If not, return the headers

If we receive a 429 status, we will store the Retry-After value in memory in a private variable as a timestamp of when the next request can be sent. 

For example, if we receive a Retry-After with 300 seconds, we would store a timestamp 300 seconds in the future

If the customer attempts to send additional batches before that timestamp, instead of making the http request, we simply return a response object with a Retry-After header calculated from the timestamp

## Master Issue
- Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4120